### PR TITLE
Specify the version of gsplat

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  
+
   <h1 align="center"><strong>🎥 [ECCV 2024] GaussCtrl: Multi-View Consistent Text-Driven 3D Gaussian Splatting Editing</strong></h3>
 
   <p align="center">
@@ -51,6 +51,8 @@ GaussCtrl is built upon NeRFStudio, follow [this link](https://docs.nerf.studio/
 
 ```bash
 pip install nerfstudio==1.0.0
+
+pip install gsplat==0.1.3
 ```
 
 Install Lang-SAM for mask extraction. 


### PR DESCRIPTION
In the original file, nerfstudio==1.0.0 relies on gsplat==0.1.2.1. When the code is running,`return_alpha` throws an exception saying that there is no such parameter. To solve this problem, you need to manually specify the version of gsplat as 0.1.3

```python
# gc_model.py
rgb, alpha = rasterize_gaussians(  # type: ignore
    self.xys,
    depths,
    self.radii,
    conics,
    num_tiles_hit,  # type: ignore
    rgbs,
    torch.sigmoid(opacities_crop),
    H,
    W,
    background=background,
    return_alpha=True,
)  # type: ignore
```
```python
# gsplat==0.13 rasterize_gaussians
def rasterize_gaussians(
    xys: Float[Tensor, "*batch 2"],
    depths: Float[Tensor, "*batch 1"],
    radii: Float[Tensor, "*batch 1"],
    conics: Float[Tensor, "*batch 3"],
    num_tiles_hit: Int[Tensor, "*batch 1"],
    colors: Float[Tensor, "*batch channels"],
    opacity: Float[Tensor, "*batch 1"],
    img_height: int,
    img_width: int,
    background: Optional[Float[Tensor, "channels"]] = None,
    return_alpha: Optional[bool] = False,
) -> Tensor:
...
```
```python
# gsplat==0.1.2.1 rasterize_gaussians
def rasterize_gaussians(
    xys: Float[Tensor, "*batch 2"],
    depths: Float[Tensor, "*batch 1"],
    radii: Float[Tensor, "*batch 1"],
    conics: Float[Tensor, "*batch 3"],
    num_tiles_hit: Int[Tensor, "*batch 1"],
    colors: Float[Tensor, "*batch channels"],
    opacity: Float[Tensor, "*batch 1"],
    img_height: int,
    img_width: int,
    background: Optional[Float[Tensor, "channels"]] = None
) -> Tensor:
...
```